### PR TITLE
Installation topic doc review

### DIFF
--- a/docs/Installing DreamFactory/docker-installation.md
+++ b/docs/Installing DreamFactory/docker-installation.md
@@ -2,9 +2,9 @@
 sidebar_position: 3
 ---
 
-# Docker Installation
+# Docker installation
 
-Our Docker container includes everything you need to run DreamFactory including Ubuntu 22.04, PHP 8.1, and the NGINX web server. It also includes all of the required PHP extensions and a sample Postgres Database, meaning you should be able to begin experimenting with the latest DreamFactory version as quickly as you can spin up the container!
+Our Docker container includes everything you need to run DreamFactory, including Ubuntu 22.04, PHP 8.1, and the NGINX web server. It also includes all required PHP extensions and a sample Postgres Database. With these tools you can begin experimenting with the latest DreamFactory version as quickly as you can spin up the container!
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ Our Docker container includes everything you need to run DreamFactory including 
 
 ## Overview
 
-The DreamFactory docker application is setup to use docker-compose.  To build and deploy the application, follow the following steps:
+The DreamFactory docker application is set up to use docker-compose. To build and deploy the application, follow these steps:
 
   1. Clone the [docker repo](https://github.com/dreamfactorysoftware/df-docker.git)
 
@@ -27,28 +27,28 @@ The DreamFactory docker application is setup to use docker-compose.  To build an
     cd df-docker
     ```
   
-  2. Edit docker-compose.yml (optional)
+  2. Edit the docker-compose.yml file (optional)
 
-    The docker-compose yaml file will have default settings for installing DreamFactory, but you may wish to edit the persistent or sample database details, usernames and passwords, or ports to access the application.  You should edit the docker-compose file prior to building and running DreamFactory.
+    The docker-compose yaml file has default settings for installing DreamFactory, but you may wish to edit the persistent or sample database details, usernames and passwords, or ports to access the application. You must edit the docker-compose file prior to building and running DreamFactory for these changes to take effect.
 
   3. Build images with `docker-compose build`
 
     :::caution Backup your APP_KEY
-    Running this after an initial deployment will rebuild the entire application unless you save and re-use the APP_KEY as described below.
+    Running this after an initial deployment rebuilds the entire application unless you save and re-use the APP_KEY as described below.
     :::
 
   4. Start containers with `docker-compose up -d`
   
-    This will spin up 4 containers:
+    This command spins up 4 containers:
     ```
     df-docker-web
       - The DreamFactory application and web portal.
     mysql:5.7
       - A MySQL container for the system database.
     redis
-      - A redis instance used for caching.
+      - A Redis instance used for caching.
     aa8y/postgres-dataset
-      - A Postgres Database with over 100k records for testing.
+      - A PostGreSQL Database with over 100k records for testing.
     ```
 
     Your terminal output should look like this:
@@ -56,41 +56,41 @@ The DreamFactory docker application is setup to use docker-compose.  To build an
 
   5. Access the Admin UI
 
-    By default, docker-compose will be on localhost port 80.  To access the application, open `http://localhost` or `http://127.0.0.1` in a browser window.
+    By default, docker-compose is on localhost port 80. To access the application, open `http://localhost` or `http://127.0.0.1` in a browser window.
     
-    The first time docker-compose is executed, it may take a few minutes to load and accept traffic.  If port 80 is taken by another application, you may edit the docker-compose yaml file to use a different port (e.g. 8080).
+    The first time docker-compose is executed, it may take a few minutes to load and accept traffic. If port 80 is taken by another application, edit the docker-compose yaml file to use a different port (e.g. 8080) and return to step 3 above.
 
-    Once the web server is live, you will briefly see a splash screen:
+    Once the web server is live, a splash screen displays briefly:
 
     ![docker splash screen](/img/docker-install/docker-compose-splash-page.png)
 
-    Continue waiting for the application to load and do not click back or refresh at this time.  Occasionally the page loads before the DB migrations are completed.  If that happens you'll see a light red screen with an error message.  In that case it is safe to allow the jobs to finish and refresh the page. After a few minutes you will see the Create a System Administrator page:
+    Continue waiting for the application to load and do not click back or refresh at this time. Occasionally the page loads before the DB migrations are completed. If that happens a light red screen with an error message displays. In that case it is safe to allow the jobs to finish and refresh the page. After a few minutes the **Create a System Administrator** page displays:
 
     ![docker create admin page](/img/docker-install/initial-login-create-admin-page.png)
 
-    Fill in the form completely and you'll be ready to use DreamFactory!
+    Complete the required fields and DreamFactory is ready to use!
 
-## Persisting System Database Configs
+## Persisting system database configs
 
 After you have spun up your DreamFactory instance, you should save the APP_KEY value from the .env file located in the web container's /opt/dreamfactory directory. This can be done with the following command while DreamFactory is running:
 
   `docker-compose exec web cat .env | grep APP_KEY`
 
-You will see a few lines output but only need to copy the APP_KEY itself (everything after `APP_KEY=` through the final `=` sign).
+A few lines of output are display, but only need to copy the APP_KEY itself (everything after `APP_KEY=` through the final `=` sign).
 
 ![app key output](/img/docker-install/app-key-output.png)
 
-Should you ever need to rebuild, set this value as the APP_KEY value in the docker-compose.yml file.  Uncomment the line in services -> web -> environment and paste your key from the above output, wrapped in single quotes.  This will allow the new build to access the previous encrypted settings and prevent data loss and errors in the application.
+Should you ever need to rebuild, set this value as the APP_KEY value in the docker-compose.yml file.  Uncomment the line in services -> web -> environment and paste your key from the above output, wrapped in single quotes.  This allows the new build to access the previous encrypted settings and prevent data loss and errors in the application.
 
 ![app key in docker-compose](/img/docker-install/app-key-docker-compose.png)
 
 :::caution Backup your docker-compose file
-If you've overridden other defaults such as database settings or ports, you'll want to backup your entire docker-compose file and compare your old values with the latest file.  Skipping this step will lead to issues when upgrading.
+If you've overridden other defaults such as database settings or ports, ensure that you backup your entire docker-compose file and compare your old values with the latest file. Skipping this step will lead to issues when upgrading.
 :::
 
-## Testing Data
+## Testing data
 
-We mount a Postgres container that contains over 100k records to test without connecting your own data sets. To utilize the container you will use the following connection details:
+We mount a PostGres container with over 100k records to test without connecting your own data sets. To utilize the container, use the following connection details:
 
   To retrieve the host IP, run: `docker inspect <container-id for postgres> | grep "IPAddress"`
 
@@ -102,9 +102,9 @@ We mount a Postgres container that contains over 100k records to test without co
   Password: root_pw
   ```
 
-Use those settings to add a new Database API Connection.  This will generate a fully documented and secure API from the Postgres container.
+Use the settings above to add a new Database API Connection. This generates a fully documented and secure API from the PostGres container.
 
-## Adding a Commercial License
+## Adding a commercial license
 
 If you are a commercial customer and have a license key for DreamFactory, you should:
   
@@ -113,25 +113,25 @@ If you are a commercial customer and have a license key for DreamFactory, you sh
   3. Add the license key to line 51 of `Dockerfile`
   4. continue with steps 2-5 above
 
-## Upgrading Your Docker Instance
+## Upgrading your Docker instance
 
-As enhancements and features get added to DreamFactory, you may wish to upgrade to a newer version.  To install a newer version of DreamFactory, you should:
+As new features and enhancements are added to DreamFactory, you may want to upgrade to a newer version. To install a newer version of DreamFactory, you should:
 
   1. Backup your existing environment
     
-    As a best practice, you should backup your files and system database before attempting to upgrade to a new version.  This includes extracting your `APP_KEY` from the existing docker container (see above).
+    As a best practice, you should back up your files and system database before attempting to upgrade to a new version.  This includes extracting your `APP_KEY` from the existing docker container (see the Persisting system database configs section above).
   
   2. Update your repo with `git pull` and `git tag --list` to see the tagged versions available.
 
-  3. Stop the DreamFactory container without deleting it with `docker-compose stop` (this will bring the instance offline until the upgrade is completed).
+  3. Stop the DreamFactory container without deleting it with `docker-compose stop` (this brings the instance offline until the upgrade is complete).
 
-  4. Checkout the newer tagged version with `git checkout tags/{version}`.
+  4. Check out the newer tagged version with `git checkout tags/{version}`.
 
   5. Add the `APP_KEY` to the docker-compose file (see above for instructions).
 
-    :::tip Be sure to enclose the `APP_KEY` with single quotes.
+    :::tip Ensure that you enclose the `APP_KEY` with single quotes.:::
   
-  6. Modify any other settings in docker-compose as needed for your environment (compare the old docker-compose file with the new on as needed).
+  6. Modify any other settings in docker-compose as needed for your environment (compare the old docker-compose file with the new one as needed).
 
   7. Save your changes and rebuild the container with `docker-compose up -d --build`.
 
@@ -139,11 +139,11 @@ As enhancements and features get added to DreamFactory, you may wish to upgrade 
 
     If any of the containers are not in a good state, you can view the logs with `docker-compose logs web` (or whatever container had the error).
   
-  9. Once the containers are all Up and running, check if the system DB schema needs a migration with `docker-compose exec web php artisan migrate:status`.  The output should look similar to:
+  9. Once the containers are all up and running, check if the system DB schema needs a migration with `docker-compose exec web php artisan migrate:status`.  The output should look similar to this:
 
     ![artisan migrate:status](/img/docker-install/docker-artisan-migrate-status.png)
 
-    If any rows don't show `Ran` for the job, you'll need to manually run the migration with `docker-compose exec web php artisan migrate`.
+    If any rows don't show `Ran` for the job, you must manually run the migration with `docker-compose exec web php artisan migrate`.
   
   10. The final step is to clear the configuration and cache with:
 
@@ -153,15 +153,15 @@ As enhancements and features get added to DreamFactory, you may wish to upgrade 
     docker-compose exec web php artisan cache:clear
     ```
 
-    After clearing the cache you should be able to open DreamFactory and verify the environment is operational.
+    After clearing the cache, open DreamFactory and verify the environment is operational.
 
-## Platform-Specific Instructions
+## Platform-specific instructions
 
 The containerized application should be compatible with any platform that supports docker and docker-compose, but depending on your system configuration, you may need to edit the `docker-compose.yml` to meet your needs.
 
-  ### Mac M-series Processors
+  ### Mac M-series processors
 
-  The docker containers were built on amd64 architecture.  Docker Desktop for Mac allows you to specify the platform even if you   are running an M-Series (M1/M2/M3) processor by adding `platform: linux/amd64` to each service in the`docker-compose.yml` file.
+  The docker containers were built on amd64 architecture.  Docker Desktop for Mac allows you to specify the platform, even if you are running an M-Series (M1/M2/M3) processor, by adding `platform: linux/amd64` to each service in the`docker-compose.yml` file.
   
   e.g.
   ```
@@ -186,4 +186,4 @@ The containerized application should be compatible with any platform that suppor
       ...
   ```
   
-  After adding the platform setting, you should be able to deploy the application on MacBook M-series processors using the   instructions above.
+  After adding the platform setting, you can deploy the application on MacBook M-series processors using the instructions above.

--- a/docs/Installing DreamFactory/installation.md
+++ b/docs/Installing DreamFactory/installation.md
@@ -4,15 +4,15 @@ sidebar_position: 1
 
 # Installing DreamFactory
 
-Welcome to the installation guide for DreamFactory! This section will focus on the inital installation of DreamFactory on the various supported platforms.
+Welcome to the installation guide for DreamFactory! This section focuses on the inital installation of DreamFactory on our supported platforms.
 
-DreamFactory is a powerful open-source REST API platform that allows you to quickly build and deploy secure and scalable applications. Whether you are running Linux, Windows, or prefer using Docker, we have got you covered. 
+DreamFactory is a powerful open-source REST API platform that allows you to quickly build and deploy secure and scalable applications. Whether you are running Linux, Windows, or prefer using Docker, we've got you covered. 
 
-To get started, choose the installation method that suits your needs:
+To get started, choose the applicable installation method:
 
-- [Linux Installation](linux-installation.md): This guide will show you how to install DreamFactory on various Linux distributions.
+- [Linux Installation](linux-installation.md): This guide details the DreamFactory installation process for various Linux distributions.
 
-- [Docker Installation](docker-installation.md): If you prefer using Docker, this guide will help you set up DreamFactory in a containerized environment.
+- [Docker Installation](docker-installation.md): If you prefer using Docker, this guide helps you set up DreamFactory in a containerized environment.
 
-- [Windows Installation](windows-installation.md): If you are using Windows, this guide will walk you through the installation process step by step.
+- [Windows Installation](windows-installation.md): If you are using Windows, this guide walks you through the installation process step by step.
 

--- a/docs/Installing DreamFactory/linux-installation.md
+++ b/docs/Installing DreamFactory/linux-installation.md
@@ -2,13 +2,13 @@
 sidebar_position: 2
 ---
 
-# Linux Installation
+# Linux installation
 
-DreamFactory can be installed on most common Linux platforms using our automated installer. The installer is designed to deploy DreamFactory as the primary application on the server (the site is publised on port 80 of the local host).  This guide provides instructions for downloading and running the installer on a new Linux server.  For custom installations or to install manually, see the [Manual Installation](manual-installation.md) guide instead.
+DreamFactory can be installed on most common Linux platforms using our automated installer. The installer is designed to deploy DreamFactory as the primary application on the server (the site is publised on port 80 of the local host).  This guide provides instructions for downloading and running the installer on a new Linux server. For custom installations or to install manually, follow the [Manual Installation](manual-installation.md) guide.
 
-## Supported Operating Systems
+## Supported operating Systems
 
-At the time of writing DreamFactory is supported on the following flavors of Linux:
+DreamFactory currently supports the following flavors of Linux:
 
 - CentOS 7
 - RHEL 7/8
@@ -19,9 +19,9 @@ At the time of writing DreamFactory is supported on the following flavors of Lin
 
 ## Automated installer
 
-The installer can be found in our Github repo [here](https://github.com/dreamfactorysoftware/dreamfactory/tree/master/installers)
+The installer can be found in [DreamFactory's GitHub repository](https://github.com/dreamfactorysoftware/dreamfactory/tree/master/installers).
 
-To execute the script on your Linux machine, simply:
+Follow these steps to execute the script on your Linux machine:
 
 1. Download the script from GitHub:
     
@@ -37,33 +37,37 @@ To execute the script on your Linux machine, simply:
 
 ### Using the installer
 
-Once the installer has started, you'll be greeted by an interactive menu:
+Once the installer opens, an interactive menu displays:
+
 ![linux installer start](/img/linux-install/df-linux-installer-start.png)
 
-The most typical installation will use options 0, 5, and 7 for a default installation of the latest version of DreamFactory with NGINX as a web server, installing and configuring MariaDB as the system database, and providing a debug log in the `/tmp/` directory.
+A typical installation uses options 0, 5, and 7 for a default build of the latest version of DreamFactory with NGINX as a web server. MariaDB is installed and configured as the system database, and a debug log is available in the `/tmp/` directory.
 
-The installer will verify the Linux platform is supported and begin installing dependencies. As each dependency is installed, you'll see a progress bar (...) and any issues that may come up. You can also tail the log file in the `/tmp` directory if needed.
+The installer verifies the Linux platform is supported and then begins installing dependencies. As each dependency is installed, a progress bar (...) is visible along with any issues that are encountered. You can also tail the log file in the `/tmp` directory if needed.
+
 ![linux installer installing](/img/linux-install/df-linux-installer-installing.png)
 
-The rest of the installer's process will provide prompts for things like the location of commercial license files, database settings, and initial admin user information. Once these prompts are complete, the installer will exit. Take note of the system DB details before closing the terminal.
+The rest of the installer's process provides prompts for you to enter the location of commercial license files, database settings, and initial admin user information. Ensure that you record the system DB details before closing the terminal.
+
 ![linux installer complete](/img/linux-install/df-linux-installer-complete.png)
 
-You should now be able to access the DreamFactory UI via a web browser by pointing to the server IP address and using the credentials you entered earlier in the installer process.
+You can now access the DreamFactory UI from a web browser by pointing to the server IP address and using the credentials created during the installer process.
+
 ![DreamFactory login page](/img/common/df-login-page.png)
 
-## About The System Database
+## About The system database
 
-During the installation, you will point DreamFactory's installation to a system database. This database will hold the entire configuration for your DreamFactory instance and can be used to replicate, restore, or upgrade an instance in the future. While the default configuration above will set up a system database on localhost, many users, especially those at scale, will want the system database to be hosted elsewhere. This configuration can be (re)entered by running the following command from the `/opt/dreamfactory/` directory:
+During the installation, you must point DreamFactory's installation to a system database. This database holds the entire configuration for your DreamFactory instance and can be used to replicate, restore, or upgrade an instance in the future. While the default configuration above can set up a system database on localhost, many users, especially those at scale, prefer the system database to be hosted elsewhere. This configuration can be (re)entered by running the following command from the `/opt/dreamfactory/` directory:
 
 `php artisan df:env`
 
 The configuration can also be changed manually by editing `/opt/dreamfactory/.env`. For more information, refer to our [DreamFactory Basic Configuration](../DreamFactory%20Configuration/configuration) documentation.
 
-### Supported System Databases
+### Supported system databases
 
 Currently, the supported system database types are:
 
-- Sqlite
+- SQLite
 - MySQL (MariaDB)
-- Postgres
+- PostgreSQL
 - SQL Server

--- a/docs/Installing DreamFactory/windows-installation.md
+++ b/docs/Installing DreamFactory/windows-installation.md
@@ -5,32 +5,32 @@ sidebar_position: 4
 
 # Windows Installation
 
-This page will have Windows installation instructions.
+This page contains installation instructions for Windows.
 
 ## Prerequisites
 
-These instructions will apply only to a fresh 64-bit Windows 2019 or 2022 Server. The server must not have any other IIS/web applications running on it in order to work with DreamFactory. You will need to be able to access the GUI of the server via something like RDP, the ability to transfer files from your client machine to the server, and it is recommended to turn IE enhanced security **off** to make downloading some of the necessary installation files easier. Other applications might be able to be ran on the same IIS instance as DreamFactory, however this is not typically supported. 
+These instructions apply only to a fresh 64-bit Windows 2019 or 2022 Server. The server must not have any other IIS/web applications running on it in order to work with DreamFactory. You must be able to access the GUI of the server using something like RDP, have the ability to transfer files from your client machine to the server, and it is recommended to turn IE enhanced security **off** to make downloading some of the necessary installation files easier. Other applications might be able to run on the same IIS instance as DreamFactory, however this is not typically supported. 
 
 A local Administrator account is also required at minimum for testing permissions, and possibly in perpetuity for IIS permissions.  
 
-## Server Role setup
+## Server role setup
 
-To start, you will need to set up the IIS Web server roles.
+To start, set up the IIS Web server roles.
 
 To enable the Web Server Roles:
 
-1. Open the Server Manager Application.
-2. Click on Option 2 "Add roles and features".
-3. Click Next.
-4. Ensure that "Role based or feature based" is selected, and click Next.
-5. Ensure the server you're working on is selected, click Next.
-6. Check the "Web Server (IIS)" box on server roles, install any admin tools if asked. Click Next.
+1. Open the **Server Manager Application**.
+2. Click on Option 2 **Add roles and features**.
+3. Click **Next**.
+4. Ensure that **Role based or feature based** is selected, and click **Next**.
+5. Ensure the server you're working on is selected, click **Next**.
+6. On server roles, check the **Web Server (IIS)** box, install any admin tools if asked, and click **Next**.
 7. Your Web Server Role should look something like this (also outlined below): 
 ![Web Server Role selection](/img/windows-install/select-server-roles.png)
-8. Click Next and then Install, let the installer run in the background, reup on coffee and start the download section below. 
+8. Click **Next** and then select **Install**. Let the installer run in the background, reup on coffee and start the download section below. 
 
-### Web server Roles
-These are the web server roles you'll want to check:
+### Web server roles
+These are the web server roles DreamFactory recommends selecting:
 
 - Web Server (IIS)
     - Common HTTP Features
@@ -50,11 +50,11 @@ These are the web server roles you'll want to check:
 
 ## Downloads
 
-There are a few installation files that will need to be downloaded and, in some cases, installed. This section will cover the downloads needed before starting the actual installation and configuration of the server. Getting all of these files on the server ahead of time will keep the rest of the installation going smoothly. 
+There are a few installation files to downloade and, in some cases, installed. This section covers the downloads needed before starting the actual installation and configuration of the server. Getting all of these files on the server ahead of time ensures that the rest of the installation runs smoothly.
 
 ### DreamFactory specific files
 
-Before starting, you will need the following files on the server ready to add to the installation when needed.
+Before starting, locate the following files on the server so they are ready to add to the installation when needed.
 
 - Composer (license) files:
   - composer.json
@@ -68,11 +68,11 @@ The composer files are typically grabbed from the DreamFactory SFTP server. Cont
 
 ### Git
 
-We will need the `git` command available to get the DreamFactory code later. 
+The `git` command must be available to get the DreamFactory code later in the installation process. 
 
-Git can be downloaded from [here](https://git-scm.com/download/win). Get the "64-bit Git for Windows Setup" version.
+Git can be downloaded from [here](https://git-scm.com/download/win). Select the **64-bit Git for Windows Setup** version.
 
-To install git, simply run the installer you downloaded and click yes/next on all default options. 
+To install git, simply run the installer you downloaded and click **yes**/**next** on all default options. 
 
 ### Visual C++ 2015-2019
 
@@ -88,29 +88,29 @@ Simply run the installer to install.
 
 ### PHP
 
-PHP for Windows can be downloaded from [here](https://windows.php.net/download#php-8.1). Be sure to get a 64-bit, **non-thread-safe (NTS)** version. Download the .zip
+PHP for Windows can be downloaded [here](https://windows.php.net/download#php-8.1). Be sure to get a 64-bit, **non-thread-safe (NTS)** version. Download the .zip file.
 
-At the time of writing, the latest supported PHP version is 8.1.27. The 64-bit NTS version can be directly downloaded from [here](https://windows.php.net/downloads/releases/php-8.1.27-nts-Win32-vs16-x64.zip)
+At the time of writing, the latest supported PHP version is 8.1.27. The 64-bit NTS version can be directly downloaded [here](https://windows.php.net/downloads/releases/php-8.1.27-nts-Win32-vs16-x64.zip).
 
-Just get the .zip downloaded. You will install it later. 
+Just get the .zip downloaded. It is installed later in the process. 
 
 ### Composer
 
-Composer is a package manager for PHP. The installer can be directly downloaded from [here](https://getcomposer.org/Composer-Setup.exe).
+Composer is a package manager for PHP. The installer can be directly downloaded [here](https://getcomposer.org/Composer-Setup.exe).
 
-Just get the installer downloaded. You will run it later. 
+Just get the installer downloaded. It is run later in the process. 
 
 ### PHP Manager
 
 PHP Manager is an IIS utility to make managing PHP and extensions much easier. 
 
-Go to the link [here]( https://www.iis.net/downloads/community/2018/05/php-manager-150-for-iis-10) and click "Download this extension". 
+Go to the link [here]( https://www.iis.net/downloads/community/2018/05/php-manager-150-for-iis-10) and click **Download this extension**. 
 
-Simply run the downloaded installer while IIS is closed to install.
+Simply run the downloaded installer while IIS is closed to complete the install.
 
-### SQL Server Drivers
+### SQL Server drivers
 
-If you plan to use DreamFactory to connect to SQL Server, you will need the driver packages. 
+If you plan to use DreamFactory to connect to a SQL Server, you must have the driver packages. 
 
 Start with downloading the v17 and v18 drivers:
 
@@ -119,28 +119,27 @@ Start with downloading the v17 and v18 drivers:
 
 Run **both** downloaded installers.
 
-For the drivers to be used, you'll also need the sqlsrv PHP extensions. Start by going to the releases page [here](https://github.com/microsoft/msphpsql/releases)
+For the drivers to be used, you also need the sqlsrv PHP extensions. Start by going to the releases page [here](https://github.com/microsoft/msphpsql/releases).
 
-Find the latest release and look in the assets section. Windows packages will be at the end of the list. Download the Windows-8.1.zip for PHP v8.1
+Find the latest release and look in the assets section. Windows packages are at the end of the list. Download the Windows-8.1.zip for PHP v8.1.
 
-As of this writing, the latest release of the extension package can be directly downloaded from [here](https://github.com/microsoft/msphpsql/releases/download/v5.12.0/Windows-8.1.zip)
+As of this writing, the latest release of the extension package can be directly downloaded [here](https://github.com/microsoft/msphpsql/releases/download/v5.12.0/Windows-8.1.zip).
 
 ## Getting DreamFactory running
 
-The rest of the procedure will involve two primary objectives: getting DreamFactory installed and running with the PHP development server, and then configuring IIS to serve DreamFactory. This section will cover the former. 
+The rest of the procedure involves two primary objectives: getting DreamFactory installed and running with the PHP development server, and then configuring IIS to serve DreamFactory. This section cover the installation and PHP development server set up. 
 
 ### Installing PHP
 
-To begin, create a new folder: `C:\php\`
-Next, grab the PHP installation .zip you gathered earlier. Extract the entire contents to the `C:\php\` folder. 
+1. Create a new folder: `C:\php\`, grab the PHP installation .zip you gathered earlier, and extract the entire contents to the `C:\php\` folder. 
 
-Duplicate (copy/paste) the `php.ini-development` file, rename the duplicate `php.ini`
+2. Duplicate (copy/paste) the `php.ini-development` file, and rename the duplicate `php.ini`.
 
 :::note
-You might need to enable file name extentions in the "view" tab of the file explorer
+You might need to enable file name extentions in the **View** tab of the file explorer.
 :::
 
-Open the newly created php.ini and copy/paste the following at the bottom of the file: 
+3. Open the newly created php.ini and copy/paste the following at the bottom of the file: 
 
 ```
 extension=ldap
@@ -174,17 +173,17 @@ zend_extension=opcache
 
 opcache.enable=1
 ```
-Save and close php.ini
+4. Save and close php.ini.
 
 :::note
-You can manually add PHP to your enviornment variable path, however this will be done automatically for us during the Composer installation. 
+You can manually add PHP to your enviornment variable path, however this is done automatically during the Composer installation. 
 :::
 
 ### Installing Composer
 
 To start, run the composer installer you downloaded earlier. 
 
-You will mostly hit "next" through most of the installtion. When asked to browse to your command line/CLI PHP naviagate to: `C:\php\php.exe`. Then check the "Add to path" option. Click Next and wait. 
+You can select **Next** through most of the installtion. When asked to browse to your command line/CLI PHP, naviagate to: `C:\php\php.exe`. Then check the **Add to path** option. Click **Next** and wait. 
 
 :::info
 This is a great time to test both the PHP and Composer installations, open a new commmand prompt and run:
@@ -193,35 +192,35 @@ This is a great time to test both the PHP and Composer installations, open a new
 
 `composer --version`
 
-If both of those commands are sucessful, you are safe to keep moving forward. 
+If both of those commands are successful, you are safe to keep moving forward. 
 :::
 
 ### Installing SQL Server drivers (optional)
 
-This again is an optional step dependent on if you intend to use DreamFactory with SQL Server.
+This is an optional step dependent on if you intend to use DreamFactory with SQL Server.
 
 The v17 and v18 drivers should have been installed during the previous steps, if not, install them now. 
 
-Open the Windows-8.1.zip you downloaded earlier, in the x64 folder there should be  4 .dll files. Copy/paste the **two** nts (Non Thread Safe) .dll into your php ext folder (`C:\php\ext\`)
+Open the Windows-8.1.zip downloaded earlier, in the x64 folder there should be 4 .dll files. Copy/paste the **two** nts (Non Thread Safe) .dll into your php ext folder (`C:\php\ext\`)
 
-Then, rename both files removing the "_81_nts" at the end of the filename. The files will be named:
+Then, rename both files removing the "_81_nts" at the end of the filename. The files are named:
 
 - php_pdo_sqlsrv.dll
 - php_sqlsrv.dll
 
 ### Get (git) DreamFactory code
 
-Next, we will get the DreamFactory code itself, to begin open a command prompt, then run:
+Next, get the DreamFactory code by opening a command prompt, and running:
 
 `cd C:\inetpub\wwwroot\`
 
 `git clone https://github.com/dreamfactorysoftware/dreamfactory`
 
-This will create a `C:\inetpub\wwwroot\dreamfactory` folder on the server which will be refered to as the DreamFactory installation folder in this and other documentation. 
+This creates a `C:\inetpub\wwwroot\dreamfactory` folder on the server, refered to as the **DreamFactory installation folder** in this and other documentation. 
 
 :::warning
 At this time, the newest supported version of DreamFactory on Windows is v5.4.1
-Version 6+ is not currently supported so the following commands will also need to be ran:
+Version 6+ is not currently supported so the following commands also need to be run:
 
 `cd C:\inetpub\wwwroot\dreamfactory`
 
@@ -232,74 +231,76 @@ Once the new UI in v6 is made compatible with Windows, this notice will be remov
 
 ### Install DreamFactory dependencies
 
-DreamFactory uses Composer to handle all PHP dependencies, if you haven't installed Composer from the installation section above, do that now. 
+DreamFactory uses Composer to handle all PHP dependencies, if you haven't installed Composer from the installation section above, do so now. 
 
 First, take your 3 composer/license files (`composer.json`, `composer.json-dist`, `composer.lock`) and add them to the DreamFactory installation directory, overwriting the existing composer files in that directory. Then, open a command prompt, cd into the dreamfactory installation directory and run:
 
 `composer install --no-dev --ignore-platform-reqs --verbose`
 
-Sometimes this command can take quite a while to run, if it feels hung, hit enter a couple times in the command prompt. 
+Sometimes this command takes a while to run, if it feels hung, hit enter a couple times in the command prompt. 
 
 ### Build DreamFactory system database and root admin
 
-Once the composer install finishes, we will finalize the DreamFactory setup, in your command prompt, cd into the dreamfactory installatoin directory. Start by running: 
-`php artisan df:env`
-This command will define the system database for the DreamFactory enviornment. For inital installation, it is recommended to start with option [0], Sqlite. If you run into problems during the installation, starting with sqlite will eliminate database/networking issues from having to troubleshoot. This database can be changed at a later date, and any configurations you build in sqlite can be exported and imported into another instance later. 
+Once the composer install finishes, we can finalize the DreamFactory setup. In your command prompt, cd into the dreamfactory installation directory. Start by running: 
+`php artisan df:env`.
+
+This command defines the system database for the DreamFactory enviornment. For initial installation, it is recommended to start with option [0], Sqlite. If you run into problems during the installation, starting with sqlite eliminates database/networking issues from the troubleshooting process. This database can be changed at a later date, and any configurations you build in sqlite can be exported and imported into another instance later. 
 
 When selecting a database name and user, it is recommended to stick with the default "dreamfactory" and "dfadmin" respectively. 
 
 Once the df:env command finishes, run:
 `php artisan df:setup`
-This command will prompt you to create your first admin user. This email and password will be used to login to the UI later. The root admin account details can be changed later.
+This command prompts you to create your first admin user. This email and password are used to log in to the UI later. The root admin account details can be changed later.
 
 Finally, add your license key to the end of the .env file located in the dreamfactory instalaltion directory. You can add it to the bottom of the file like:
 `DF_LICENSE_KEY={YOUR LICENSE KEY}`
-> without the curly brackets
+
+:::note Ensure that you remove curly brackets seen in the example above.:::
 
 ### Test DreamFactory
 
-In order to run a test/development Laravel server, from the dreamfactory installation direfctory run:
+In order to run a test/development Laravel server, from the dreamfactory installation directory run:
 `php artisan serve`
 
-This will start a web server at http://127.0.0.1:8000 If you can navigate to this url, login to the UI with the root admin created earlier, and you **don't** have a red banner at the top of the UI, you have done everything correctly. If not, go back and check the steps you missed before moving forward. 
+This starts a web server at http://127.0.0.1:8000. If you can navigate to this url, login to the UI with the root admin created earlier. If you **don't** have a red banner at the top of the UI, you have done everything correctly. If the red banner is still visible, go back and check for any steps you may have missed before moving forward. 
 
-From here, DreamFactory is installed, the next section will focus on getting IIS to serve DreamFactory on port 80
+From here, DreamFactory is installed, the next section focuses on getting IIS to serve DreamFactory on port 80.
 
 ## Serving DreamFactory with IIS
 
-This section will highlight the IIS configuration needed to serve DreamFactory. 
+This section highlights the IIS configuration needed to serve DreamFactory. 
 
 :::note
-Please note that we at DreamFactory are not Windows experts. The guidance provided herein outlines a basic, default IIS configuration that has been tested and is known to work with DreamFactory on Windows environments. This setup is intended as a foundation or starting point for your DreamFactory installation. It's important to understand that while this configuration works for us and is supported by our team, Windows and IIS are versatile platforms. As such, there may be alternative configurations that also work well, depending on your specific needs and environment. We encourage you to use this as a guide, but feel free to explore and implement what works best for your situation.
+We at DreamFactory are not Windows experts. The guidance provided here outlines a basic, default IIS configuration that has been tested and is known to work with DreamFactory on Windows environments. This setup is intended as a foundation for your DreamFactory installation. It's important to understand that while this configuration works for us and is supported by our team, Windows and IIS are versatile platforms. As such, there may be alternative configurations that also work well, depending on your specific needs and environment. We encourage you to use this as a guide, but feel free to explore and implement what works best for your situation.
 :::
 
-To begin, open the IIS manager, most of the steps here will take place in the IIS manager. 
+To begin, open the IIS manager, most of the steps here take place in the IIS manager. 
 
 ### Create DreamFactory site
 
-In the left panel of the IIS manager UI, open "sites" and right click > remove the default site.
+In the left panel of the IIS manager UI, open **sites**, right click, and select **remove the default site**.
 
-Next, right click on the "sites" folder and then "Add Website". Then fill in the dialog
+Next, right click on the **sites** folder and select **Add Website**. Then fill in the dialog:
 
 - Site name: typically set to "dreamfactory" but can be whatever you'd like
 - Physical Path: `{dreamfactory install dir}/public` if you've been following along this should be: `C:\inetpub\wwwroot\dreamfactory\public\`
 - Connect as...
- - For the default DreamFactory configuration, the "Connect As" should be set to a **local server Administrator account** set under the "Specific User" option. Other options such as domain users can be used, however you might run into permission issues that you will need to solve. DreamFactory support is able to support the local Administrator account, but is unable to help with setting domain/non local admin account permissions. 
- - Use the "Test Settings" button, and ensure you have two green check marks. 
+  - For the default DreamFactory configuration, the "Connect As" should be set to a **local server Administrator account** set under the **Specific User** option. Other options such as domain users can be used, however you might run into permission issues that will need to be solved. DreamFactory support is able to support the local Administrator account, but is unable to help with setting domain/non-local admin account permissions. 
+  - Use the "Test Settings" button, and ensure you have two green check marks. 
 
 :::note
-Due to the vast diversity in Windows environments, initial testing of DreamFactory necessitates the use of the local Administrator account. If DreamFactory is accessible with the local Administrator account but encounters issues with domain or non-admin user accounts, the problem often lies within permissions. We strongly recommend and support the use of the local Administrator account. Troubleshooting permission issues will likely be required for non-admin accounts to resolve access discrepancies.
+Due to the vast diversity in Windows environments, initial testing of DreamFactory necessitates the use of the local Administrator account. If DreamFactory is accessible with the local Administrator account but encounters issues with domain or non-admin user accounts, the problem often stems from permissions issues. We strongly recommend and support the use of the local Administrator account. Troubleshooting permission issues is often required for non-admin accounts to resolve access discrepancies.
 :::
 
 ### Handler mappings
 
-Handler mappings tell IIS how/where to use the php executeables in serving DreamFactory. To start, select the server on the lefthand side of the IIS manager. Then, click on the "Handler Mappings" icon. To create a new mapping, click "Add Module Mapping" on the righthand side. 
+Handler mappings tell IIS how/where to use the php executables in serving DreamFactory. Select the server on the left side of the IIS manager and click on the **Handler Mappings** icon. To create a new mapping, on the right side of the page, click **Add Module Mapping**. 
 
-Fill in the Add Module Mapping dialog:
+Fill in the **Add Module Mapping** dialog:
 
 - Request Path: `*.php`
 - Module: `FastCgiModule`
-- Executeable: `C:\php\php-cgi.exe`
+- Executable: `C:\php\php-cgi.exe`
 - Name: `PHP_via_FastCGI`
 
 Next, click on request restricions, and ensure the following are set:
@@ -308,29 +309,29 @@ Next, click on request restricions, and ensure the following are set:
 - Verbs: all
 - Access: script
 
-Click "OK" to save the handler mapping. 
+Click **OK** to save the handler mapping. 
 
-### PHP Manager config
+### PHP manager config
 
-Again, from the server view on the left, but this time click on the "PHP Manager" icon. 
+Again, from the server view on the left, click on the **PHP Manager** icon. 
 
-You will likley see a yellow notice that your PHP configuration is non optimal. Click on "View Recomendations" check the boxes and apply every available recommendation.
+Generally a yellow notice that your PHP configuration is non optimal is displayed. Click on **View Recomendations**, check the boxes and apply every available recommendation.
 
-Test that PHP is working, click the "Check phpinfo()" link and then test using the dreamfactory site. Ensure that you see a purple and white PHP info output in this screen. If not, go back and resolve PHP installation issues. 
+Test that PHP is working, click the **Check phpinfo()** link and then test using the DreamFactory site. Ensure that you see a purple and white PHP info output in this screen. If not, go back and resolve any PHP installation issues. 
 
-If your php.ini is built correctly from above, you should be able to access "Enable or disable an extention" and see them enabled. You can also enable extentions manually in the PHP Manager which will apply the appropriate edits to the `php.ini` file
+If your php.ini is built correctly you should be able to access **Enable or disable an extention** and see them enabled. You can also enable extentions manually in the PHP Manager which applies the appropriate edits to the `php.ini` file.
 
 ### FastCGI settings
 
-There is one small setting change to be made here to the default IIS error handling. 
+There is one setting change to be made to the default IIS error handling. 
 
-From the server view, select "FastCGI Settings", then slect the handler you made earlier and then "Edit..." on the right side. 
+From the server view, select **FastCGI Settings**, then select the handler you made earlier and click **Edit...**. 
 
-Change "Standard Error Mode" to "IgnoreAndReturn200" and click "OK" 
+Change **Standard Error Mode** to **IgnoreAndReturn200** and click **OK**. 
 
 ### Request filtering
 
-From the server view, select "Request Filtering" icon. Then Navigate to the "HTTP Verbs" tab. On the right side, click "Allow Verb" and add the following verbs one at a time:
+From the server view, select the **Request Filtering** icon. Then Navigate to the **HTTP Verbs** tab. On the right side, click **Allow Verb** and add the following verbs one at a time:
 
 - GET
 - HEAD
@@ -339,26 +340,26 @@ From the server view, select "Request Filtering" icon. Then Navigate to the "HTT
 - PUT
 - PATCH
 
-### URL Rewrite rules
+### URL rewrite rules
 
-Next, on the left hand side of the IIS management window, open the dreamfactory site, and then click on "URL Rewrite" module. To import the URL rewrite rules:
+On the left side of the IIS management window, open the DreamFactory site, and select the **URL Rewrite** module. To import the URL rewrite rules:
 
-1. Click "Import Rules" on the right side 
-2. Browse to the dreamfactory/public dir and open .htaccess
-3. click "import"
-4. If any of the imported rules have red "X"s on them, select them and remove that specific rule until everything in green checkmarks. 
-5. click "apply" on the right side. 
+1. on the right side of the page, click **Import Rules**. 
+2. Browse to the dreamfactory/public dir and open **.htaccess**.
+3. Click **Import**.
+4. If any of the imported rules have red **X**s on them, select them and remove that specific rule until everything shows a green checkmark. 
+5. Click **Apply** to complete the process. 
 
 ### Directory permissions
 
-IIS needs control over certian folders within the dreamfactory installation directory in order to function properly. Right click > properties on the following folders and give IIS_IUSRS full control over them. Additionally, be sure to unckeck the "read only" option, and apply all changes recursively if asked:
+IIS needs control over certian folders within the DreamFactory installation directory in order to function properly. Right click and select **Properties** on the following folders and give IIS_IUSRS full control over them. Additionally, be sure to unckeck the **read only** option, and apply all changes recursively if asked:
 
 - `storage`
 - `bootstrap/cache`
 - `public`
 
 :::note
-Sometimes these permisions don't set correctly with the properties window. If you are having permissions issues, we have seen good results using these two commands ran from the dreamfactory install directory:
+Sometimes these permisions don't set correctly with the properties window. If you are having permissions issues, we have seen good results by running these two commands from the DreamFactory install directory:
 
 `icacls "bootstrap\cache" /grant "IIS_IUSRS:(OI)(CI)F"`
 
@@ -368,8 +369,8 @@ Sometimes these permisions don't set correctly with the properties window. If yo
 
 ### Accessing DreamFactory
 
-After completing the setup, you can navigate to the server's IP address or hostname to view the DreamFactory login screen on port 80. At this stage, DreamFactory is operational. However, implementing SSL and creating a DNS entry for the server are examples of the numerous additional configuration options at your disposal. Due to the extensive variety of configurations possible beyond this point, this guide does not cover them in detail. For more advanced IIS configuration, please consult Microsoft's documentation as needed.
+After completing the setup, you can navigate to the server's IP address or hostname to view the DreamFactory login screen on port 80. At this stage, DreamFactory is operational. However, implementing SSL and creating a DNS entry for the server are some of the many additional configuration options at your disposal. Due to the extensive variety of configurations possible beyond this point, this guide does not cover them in detail. For more advanced IIS configuration, consult Microsoft's documentation as needed.
 
 ## Adding SSL
 
-We typically recommend [certbot](https://certbot.eff.org/instructions?ws=other&os=windows) follow instructions there. 
+For details on adding SSL, DreamFactory recommends using [certbot](https://certbot.eff.org/instructions?ws=other&os=windows). Follow the instructions from the provided link to help you through the process. 


### PR DESCRIPTION
Updates to installation topics, including reformatting of topic titles, steps, replacing "" with bold text **, and other changes. One major formatting issue I located in the docker installation topic. the triple colon starting at step 6 in the Upgrading Your Docker Instance section was not closed resulting in the rest of that topic being highlighted in green.