### PR TITLE
Minor change to mysqldump commands and added scp commands

### DIFF
--- a/docs/DreamFactory Upgrades and Migrations/migrating-dreamfactory.md
+++ b/docs/DreamFactory Upgrades and Migrations/migrating-dreamfactory.md
@@ -5,11 +5,6 @@ title: Migrating DreamFactory
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::warning
-
-This page is under construction.
-
-:::
 # Migrating Your DreamFactory Instance
 
 DreamFactory often acts as a reliable "set it and forget it" platform, running seamlessly for extended periods with minimal maintenance. However, there may be scenarios where you need to migrate your DreamFactory instance to a new server or environment. This guide outlines the migration process, focusing on two critical components: the `.env` file and the DreamFactory system database.
@@ -34,23 +29,67 @@ The DreamFactory system database stores:
 
 Migrating these ensures your new DreamFactory instance contains all your original configurations and data, eliminating the need for manual recreation of your environment.
 
+### File Transfer Reference
+:::info[CLI File Transfer Method by Deployment]
+<Tabs>
+  <TabItem value="vm/linux" label="VM/Linux">    
+    **FROM remote TO local**
+    ```bash
+    scp <user>@<remote-server>:/path/to/file local-destination/
+    ```
+    *ex. `scp root@192.168.1.100:/opt/dreamfactory/.env .`*
+    
+    **FROM local TO remote**
+    ```bash
+    scp local-source <user>@<remote-server>:/path/to/destination/
+    ```
+    *ex. `scp dump.sql root@192.168.1.100:/opt/dreamfactory/`*
+  </TabItem>
+  <TabItem value="docker" label="Docker">
+    **FROM container TO local**
+    ```bash
+    docker cp <container_name_or_id>:/path/to/file local-destination/
+    ```
+    *ex. `docker cp df-docker-web-1:/opt/dreamfactory/.env .`*
+
+    **FROM local TO container**
+    ```bash
+    docker cp local-source <container_name_or_id>:/path/to/destination/
+    ```
+    *ex. `docker cp dump.sql df-docker-web-1:/opt/dreamfactory/`*
+  </TabItem>
+  <TabItem value="kubernetes" label="Kubernetes">
+    **FROM pod TO local**
+    ```bash
+    kubectl cp <namespace>/<pod-name>:/path/to/file local-destination/
+    ```
+    *ex. `kubectl cp df-namespace/df-pod:/opt/dreamfactory/.env .`*
+
+    **FROM local TO pod**
+    ```bash
+    kubectl cp local-source <namespace>/<pod-name>:/path/to/destination/
+    ```
+    *ex. `kubectl cp dump.sql df-namespace/df-pod:/opt/dreamfactory/`*
+  </TabItem>
+</Tabs>
+:::
+
 ---
 
 ## Step-by-Step Migration Guide
 
 ### Step 1: Back Up the `.env` File
 
-1. Navigate to the DreamFactory root directory:  
+1. **Navigate to the DreamFactory root directory:**  
    ```bash
    cd /opt/dreamfactory
    ```
 
-2. Copy the `.env` file to a secure location:  
+2. **Copy the `.env` file to a secure location/your local machine:**
    ```bash
-   cp .env ~/.env
+   scp <user>@<remote-server>:/opt/dreamfactory/.env .
    ```
-
-3. Use SFTP or another tool to transfer the `.env` file to an external location for safekeeping.
+   *For more information on file transfer methods, see [File Transfer Reference](#file-transfer-reference)*
 
 **Tip:** Storing a copy of the `.env` file off-server ensures you can recover from any issues during the migration.
 
@@ -59,35 +98,38 @@ Migrating these ensures your new DreamFactory instance contains all your origina
 ### Step 2: Back Up the System Database
 
 1. Use the system database credentials from the `.env` file to back up the system database.
+    :::info[Backup Method by Database Type]
+    <Tabs>
+      <TabItem value="mysql" label="MySQL">
+        ```bash
+        mysqldump -u root -p --databases dreamfactory --no-create-db > dump.sql
+        ```
+      </TabItem>
+      <TabItem value="sqlserver" label="MS SQL Server">    
+        ```bash
+        Use SSMS (SQL Server Management Studio) to export the database to a file.
+        ```
+      </TabItem>
+      <TabItem value="postgresql" label="PostgreSQL">
+        ```bash
+        pg_dump -U root -d dreamfactory -F p > dump.sql
+        ```
+      </TabItem>
+      <TabItem value="sqlite" label="SQLite">
+        ```bash
+        sqlite3 dreamfactory.db ".dump" > dump.sql
+        ```
+      </TabItem>
+    </Tabs>
+    :::
 
-:::info[Backup Method by Database Type]
-<Tabs>
-  <TabItem value="mysql" label="MySQL">
-    ```bash
-    mysqldump -u df_admin -p --databases dreamfactory --no-create-db > ~/dump.sql
-    ```
-  </TabItem>
-  <TabItem value="sqlserver" label="MS SQL Server">    
-    ```bash
-    Use SSMS (SQL Server Management Studio) to export the database to a file.
-    ```
-  </TabItem>
-  <TabItem value="postgresql" label="PostgreSQL">
-    ```bash
-    pg_dump -U df_admin -d dreamfactory -F p > ~/dump.sql
-    ```
-  </TabItem>
-  <TabItem value="sqlite" label="SQLite">
-    ```bash
-    sqlite3 dreamfactory.db ".dump" > ~/dump.sql
-    ```
-  </TabItem>
-</Tabs>
-:::
+2. Replace `root` with a different database user if desired, and `dreamfactory` with your database name (if different).
 
-2. Replace `df_admin` with your database user, and `dreamfactory` with your database name (if different).
-
-3. Transfer the backup file (`dump.sql`) to a secure external location, just as you did with the `.env` file.
+3. **Transfer the backup file (`dump.sql`) to a secure external location:**
+    ```bash
+    scp <user>@<remote-server>:/opt/dreamfactory/dump.sql .
+    ```
+    *For more information on file transfer methods, see [File Transfer Reference](#file-transfer-reference)*
 
 ---
 
@@ -114,6 +156,11 @@ Ensure all system dependencies, such as PHP, are up to date. DreamFactory suppor
 ### Step 5: Import the System Database Backup
 
 1. **Transfer the `dump.sql` file to the new server.**
+    ```bash
+    scp dump.sql <user>@<new-server>:/opt/dreamfactory/
+    ```
+    *For more information on file transfer methods, see [File Transfer Reference](#file-transfer-reference)*
+
 2. **Clear the default database schema:**
    ```bash
    php artisan migrate:fresh
@@ -123,30 +170,30 @@ Ensure all system dependencies, such as PHP, are up to date. DreamFactory suppor
    ```
 
 3. **Import the database backup:**
-:::info[Import Method by Database Type]
-<Tabs>
-  <TabItem value="mysql" label="MySQL">
-    ```bash
-    mysql -u df_admin -p dreamfactory < ~/dump.sql
-    ```
-  </TabItem>
-  <TabItem value="sqlserver" label="MS SQL Server">    
-    ```bash
-    Use SSMS (SQL Server Management Studio) to import the database from the file.
-    ```
-  </TabItem>
-  <TabItem value="postgresql" label="PostgreSQL">
-    ```bash
-    psql -U df_admin -d dreamfactory < ~/dump.sql
-    ```
-  </TabItem>
-  <TabItem value="sqlite" label="SQLite">
-    ```bash
-    sqlite3 dreamfactory.db < ~/dump.sql
-    ```
-  </TabItem>
-</Tabs>
-:::
+    :::info[Import Method by Database Type]
+    <Tabs>
+      <TabItem value="mysql" label="MySQL">
+        ```bash
+        mysql -u root -p dreamfactory < dump.sql
+        ```
+      </TabItem>
+      <TabItem value="sqlserver" label="MS SQL Server">    
+        ```bash
+        Use SSMS (SQL Server Management Studio) to import the database from the file.
+        ```
+      </TabItem>
+      <TabItem value="postgresql" label="PostgreSQL">
+        ```bash
+        psql -U root -d dreamfactory < dump.sql
+        ```
+      </TabItem>
+      <TabItem value="sqlite" label="SQLite">
+        ```bash
+        sqlite3 dreamfactory.db < dump.sql
+        ```
+      </TabItem>
+    </Tabs>
+    :::
 
 4. **Run database migrations to apply schema updates:**
    ```bash


### PR DESCRIPTION
Changed mysqldump / mysql import commands to use root instead of df_admin as example due to permissions issues when testing non-root users.

Also added a table for different file transfer mechanisms based on deployment (Linux/Docker/Kubernetes) for users to reference.