### PR TITLE
docs: cover the features shipping in the current composer set

### DIFF
--- a/docs/AI/agents.md
+++ b/docs/AI/agents.md
@@ -1,0 +1,113 @@
+---
+sidebar_position: 11
+title: Agents
+id: agents
+description: "Register AI agents in DreamFactory with their own identity, role-scoped API key, and skills, and route tasks to the right agent with a deterministic capability router"
+keywords: [AI agents, agent identity, capability router, agent registry, RBAC, API key, skills]
+difficulty: "intermediate"
+---
+
+# Agents
+
+The **Agents** service gives every AI agent its own identity inside DreamFactory: a named record, a role that scopes what it may reach, its own API key with an optional lifetime, and a list of skills. Because an agent is a first-class record rather than a shared key, you can see which agent did what, revoke one without disturbing the others, and route work to the right agent programmatically.
+
+Create the service from **API Generation & Connections** by adding a service of type **Agents**. It exposes three resources:
+
+| Resource | Purpose |
+| --- | --- |
+| `/api/v2/agents/agents` | The agent registry — create, read, update, delete agents |
+| `/api/v2/agents/requests` | The pending access-request queue |
+| `/api/v2/agents/route` | Deterministic capability router (POST only) |
+
+---
+
+## Registering an agent
+
+An agent record carries:
+
+| Field | Description |
+| --- | --- |
+| `name` | The agent's name. Also scored by the router. |
+| `description` | Free-text description. Also scored by the router. |
+| `role_id` | The role that scopes what this agent may reach. |
+| `owner_id` | The user who owns the agent. |
+| `api_key` | The agent's own API key. |
+| `key_ttl_hours` | Optional lifetime for the key, in hours. |
+| `skills` | JSON array of capability keywords, for example `["invoice reconciliation", "refunds"]`. |
+| `chat_service_id` | Optional AI chat service to use as this agent's persona. |
+| `is_active` | Only active agents are considered by the router. |
+
+Scope each agent with a role exactly as you would an application. See [Role-Based Access Control](/Security/role-based-access).
+
+---
+
+## Approving access requests
+
+Requests queue under `/api/v2/agents/requests`. Approving or denying one is a `PATCH` that sets the status — the model applies the side effects, including the resolution stamp, key rotation on approval, and the alert:
+
+```bash
+curl -X PATCH \
+  "https://{instance}/api/v2/agents/requests/{id}" \
+  -H "X-DreamFactory-API-Key: {api_key}" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "approved"}'
+```
+
+Use `"denied"` to reject. The admin UI's one-click approve is this same call.
+
+---
+
+## Routing a task to an agent
+
+`POST /api/v2/agents/route` answers "which registered agent should handle this?" without calling a model. The scoring is pure and deterministic: the same task and the same registry always produce the same answer.
+
+```bash
+curl -X POST \
+  "https://{instance}/api/v2/agents/route" \
+  -H "X-DreamFactory-API-Key: {api_key}" \
+  -H "Content-Type: application/json" \
+  -d '{"task": "reconcile last month'\''s invoices", "top": 3}'
+```
+
+| Field | Description |
+| --- | --- |
+| `task` | **Required.** Free-form description of the work. |
+| `top` | How many scored agents to return. Defaults to `3`, clamped to `1`–`25`. |
+
+A match returns the winner, its chat persona service if one is configured, a human-readable reason, and the leaderboard:
+
+```json
+{
+  "routed_to": { "id": 4, "name": "Finance Bot" },
+  "chat_service_id": 12,
+  "chat_service": "finance_chat",
+  "reason": "matched: skill:invoice reconciliation",
+  "scores": [
+    { "id": 4, "name": "Finance Bot", "score": 4 },
+    { "id": 7, "name": "Support Bot", "score": 1 }
+  ]
+}
+```
+
+When nothing scores above zero, `routed_to` and the chat fields are `null` and `reason` is `no registered agent matches` — the caller decides what to do next.
+
+### How scoring works
+
+Only active agents are considered. The task, each skill keyword, and each agent's name plus description are tokenized the same way: lowercased, split on runs of non-alphanumeric characters, tokens shorter than three characters dropped, then de-duplicated. Then:
+
+- **+3** for each skill keyword whose tokens *all* appear in the task, so a multi-word skill like `invoice reconciliation` counts once as a single hit rather than twice as two words
+- **+1** for each name or description token found in the task, skipping any token already counted as part of a matched skill, so nothing is double-counted
+
+Results are sorted by score, ties broken by lowest id. The practical consequence: **skills drive routing**, and name and description only break ties. If an agent is being picked for the wrong work, edit its skills first.
+
+:::note[The router returns a decision, never a credential]
+The response contains an agent id, name, and chat service. It never returns `api_key` or any other credential material — the routing call is safe to expose to a client that is not itself trusted with agent keys. `GET` is not supported on this resource; routing is a computed action, so it is `POST` only.
+:::
+
+---
+
+## Next steps
+
+- **[Role-Based Access Control](/Security/role-based-access)**: Scope what an agent may reach
+- **[AI Chat](/AI/ai-chat)**: Configure the chat service an agent uses as its persona
+- **[MCP Server](/AI/mcp-server)**: Expose your APIs to agents as tools

--- a/docs/AI/ai-chat.md
+++ b/docs/AI/ai-chat.md
@@ -181,6 +181,25 @@ The response includes a `messages` array where each message has:
 
 Deletes the session and all its messages. Non-admins can only delete their own sessions.
 
+## Suggested follow-ups
+
+When an assistant reply ends with a fenced block tagged `suggestions`, the chat UI turns each line of that block into a clickable follow-up chip and hides the block itself from the rendered message. Clicking a chip sends it as the next message.
+
+Only a **closed fence at the very end** of the message is treated this way — a `suggestions` block in the middle of a reply is rendered as ordinary code, so a model explaining the convention does not accidentally produce chips.
+
+Parsing is deliberately conservative: at most **four** chips are shown, a line longer than 120 characters is dropped rather than truncated, and a stray leading bullet or numbering (`-`, `*`, `•`, `1.`) is tolerated and stripped.
+
+To offer follow-ups, have your system prompt end replies with:
+
+````text
+```suggestions
+Show me last quarter instead
+Break this down by region
+```
+````
+
+The feature needs no configuration; it activates whenever a reply carries the fence.
+
 ## AI Chat vs. Data Chat
 
 DreamFactory provides two ways to chat with your data:

--- a/docs/AI/ai-usage-monitoring-and-cost-allocation.md
+++ b/docs/AI/ai-usage-monitoring-and-cost-allocation.md
@@ -74,6 +74,16 @@ The by-app panels are the chargeback view: because each application is an API ke
 
 The most-expensive-calls table lists individual requests with their attribution, token counts, and estimated cost — the drill-down level for "what was that spike?" questions.
 
+### Estimating a task before you run it
+
+The **task cost estimator** answers the forward-looking question: *what would one agent task cost?* Rather than quoting a price, it calibrates against your own metered history and projects a range.
+
+It reads per-call average input and output tokens from a window of your real usage, then multiplies them by the observed number of provider calls one routed task fans out into — a plan step, one or more tool calls, and a final answer. That fan-out is a **range of 3 to 6 calls**, which is why the result is a range rather than a single number, and why token figures are rounded to the nearest hundred: the arithmetic does not support more precision than that.
+
+Calibration needs a minimum number of metered requests in the window before it will project anything. If the window is too thin, widen it or run more traffic first.
+
+Given an optional budget, the estimator also judges the projected range against it, and after a real run it classifies actual spend against what was projected — so the estimate can be checked rather than trusted.
+
 ![Top most expensive calls ledger](/img/ai/usage-monitoring/top-expensive-calls.png)
 
 ## Reading Usage via the API

--- a/docs/_ai-reference.md
+++ b/docs/_ai-reference.md
@@ -21,7 +21,7 @@ This document provides structured, machine-readable information about DreamFacto
 | **Product Type** | REST API Platform / API Gateway |
 | **Primary Function** | Automatic API generation from data sources |
 | **License Types** | Open Source (OSS), Commercial (Gold, Silver) |
-| **Backend Technology** | PHP 8.1+, Laravel Framework |
+| **Backend Technology** | PHP 8.3+, Laravel Framework |
 | **Database Support** | MySQL, PostgreSQL, SQL Server, Oracle, MongoDB, Cassandra, CouchDB, and more |
 | **Authentication Support** | API Key, JWT, OAuth 2.0, SAML 2.0, LDAP, Active Directory, OpenID Connect |
 | **MCP Support** | Yes - Model Context Protocol for AI assistant integration |

--- a/docs/api-generation-and-connections/api-types/database/bigquery.md
+++ b/docs/api-generation-and-connections/api-types/database/bigquery.md
@@ -1,0 +1,125 @@
+---
+sidebar_position: 7
+title: Google BigQuery
+id: bigquery
+description: "Connect Google BigQuery to DreamFactory and generate a secure REST API with full read and write access to your datasets"
+keywords: [BigQuery, Google Cloud, database API, REST API, data warehouse, analytics, service account]
+difficulty: "intermediate"
+---
+
+# Connecting Google BigQuery to DreamFactory
+
+This guide walks you through connecting Google BigQuery to DreamFactory to auto-generate a secure REST API over your datasets. You'll learn how to:
+
+- Authenticate with a Google Cloud service account and expose a BigQuery dataset as REST endpoints
+- Read, filter, and aggregate table data
+- Insert, update, and delete rows, and what BigQuery's lack of primary keys means for those calls
+- Reach the same dataset from an AI agent through DreamFactory's MCP server
+
+---
+
+## Prerequisites
+
+Before connecting BigQuery to DreamFactory, ensure you have:
+
+- **A Google Cloud project** with the BigQuery API enabled and at least one dataset
+- **A service account key** — a JSON key file for a service account with access to the dataset
+- **DreamFactory Installation**: An up-and-running DreamFactory instance with access to the Admin application
+
+:::tip[Least privilege]
+Grant the service account only the roles it needs. `BigQuery Data Viewer` is enough for a read-only API; add `BigQuery Data Editor` only if you intend to write, and `BigQuery Job User` so it can run queries.
+:::
+
+---
+
+## Connecting BigQuery
+
+Sign into your DreamFactory instance, navigate to **API Generation & Connections**, and create a new service of type **BigQuery**.
+
+### Configuration
+
+| Field | Description |
+| --- | --- |
+| **Application Credentials JSON** | The **contents** of your service account key JSON file, pasted in full — not a path to it. |
+| **Project ID** | Your Google Cloud project ID. |
+| **Location** | The dataset location, for example `US` or `europe-west2`. See [BigQuery locations](https://cloud.google.com/bigquery/docs/locations). |
+| **Auth Cache Store** | Which cache connection holds the auth token. Supported: `apc`, `array`, `database`, `file`, `memcached`, `redis`. |
+| **Options** | Additional name/value parameters passed to the underlying BigQuery client: `authCacheOptions`, `authHttpHandler`, `httpHandler`, `retries`, `scopes`, `returnInt64AsObject`. |
+
+Once saved, DreamFactory introspects the dataset and generates endpoints under `/api/v2/{service_name}/_table/{table_name}`, along with `_schema` endpoints describing the tables and columns.
+
+---
+
+## Reading data
+
+Reads work as they do for any DreamFactory database service — see [Querying and Filtering Records](./querying-and-filtering) for the full syntax.
+
+```bash
+curl -X GET \
+  "https://{instance}/api/v2/{service_name}/_table/{table_name}?limit=10" \
+  -H "X-DreamFactory-API-Key: {api_key}"
+```
+
+Filtering, field selection, ordering, grouping, and aggregation (`SUM`, `COUNT`, `AVG`, `MIN`, `MAX`) are all supported.
+
+---
+
+## Writing data
+
+BigQuery services support the full set of write verbs: `POST` to insert, `PUT`/`PATCH` to update, and `DELETE` to remove rows.
+
+### Inserting
+
+```bash
+curl -X POST \
+  "https://{instance}/api/v2/{service_name}/_table/{table_name}" \
+  -H "X-DreamFactory-API-Key: {api_key}" \
+  -H "Content-Type: application/json" \
+  -d '{"resource": [{"id": 1, "name": "Example"}]}'
+```
+
+### Updating and deleting by filter
+
+```bash
+curl -X PATCH \
+  "https://{instance}/api/v2/{service_name}/_table/{table_name}?filter=(status='pending')" \
+  -H "X-DreamFactory-API-Key: {api_key}" \
+  -H "Content-Type: application/json" \
+  -d '{"status": "complete"}'
+```
+
+:::warning[BigQuery has no primary keys]
+This is the one place a BigQuery API behaves differently from DreamFactory's other SQL connectors.
+
+BigQuery does not enforce primary keys or uniqueness, so DreamFactory cannot infer an identifier column. Operations addressed by id — `PUT`, `PATCH`, `DELETE`, or `GET` on `/_table/{table_name}/{id}`, and calls using `?ids=` — require you to name the column explicitly with **`id_field`**:
+
+```bash
+curl -X DELETE \
+  "https://{instance}/api/v2/{service_name}/_table/{table_name}/42?id_field=order_id" \
+  -H "X-DreamFactory-API-Key: {api_key}"
+```
+
+Without it the request fails with:
+
+> BigQuery has no primary keys; supply an id_field to update, delete or fetch by id, or use a filter.
+
+Because uniqueness is not enforced, an id-addressed call may legitimately match zero rows or several. DreamFactory does not treat a mismatch between the number of ids sent and the number of rows affected as an error, so check the response rather than assuming a one-to-one result. Where you can, prefer filter-based calls, which express the intent directly.
+:::
+
+:::note[DML requires a WHERE clause]
+BigQuery requires a predicate on `UPDATE` and `DELETE`. DreamFactory builds one from your `filter` or from the ids you supply, which means an unfiltered "update everything" call is rejected by BigQuery rather than silently rewriting the table.
+:::
+
+---
+
+## Using BigQuery with AI agents
+
+BigQuery services register in DreamFactory's **Database** service group, so the [MCP Server](/AI/mcp-server) discovers them automatically and exposes the standard database tools for them — schema exploration, querying, aggregation, and record management — prefixed with the service name.
+
+---
+
+## Next steps
+
+- **[Querying and Filtering Records](./querying-and-filtering)**: The full filter, sort, and aggregation syntax
+- **[Role-Based Access Control](/Security/role-based-access)**: Restrict which tables and verbs a key can reach
+- **[MCP Server](/AI/mcp-server)**: Expose this dataset to AI agents

--- a/docs/api-generation-and-connections/api-types/database/database-overview.md
+++ b/docs/api-generation-and-connections/api-types/database/database-overview.md
@@ -24,9 +24,10 @@ These database connectors are included in DreamFactory OSS and all commercial ed
 | Database | Driver | Default Port | Documentation |
 | -------- | ------ | ------------ | ------------- |
 | **PostgreSQL** | `pdo_pgsql` | 5432 | [PostgreSQL Guide](./postgresql) |
-| **MySQL / MariaDB** | `pdo_mysql` | 3306 | [MySQL Guide](./generating-database-backed-api) |
+| **MySQL / MariaDB** | `pdo_mysql` | 3306 | [MySQL Guide](./generating-a-database-backed-api) |
 | **SQLite** | `pdo_sqlite` | N/A (file) | [SQLite Guide](./sqlite) |
 | **Google AlloyDB** | `pdo_pgsql` | 5432 | [AlloyDB Guide](./alloydb) |
+| **Google BigQuery** | none (HTTP API) | N/A (cloud) | [BigQuery Guide](./bigquery) |
 
 ### Commercial License Required
 
@@ -195,11 +196,12 @@ Layer DreamFactory's RBAC on top of database permissions:
 
 ## Next Steps
 
-- **[Generating a Database-Backed API](./generating-database-backed-api)**: Step-by-step guide for your first database API
-- **[Querying & Filtering](./querying-filtering)**: Learn advanced query syntax
+- **[Generating a Database-Backed API](./generating-a-database-backed-api)**: Step-by-step guide for your first database API
+- **[Querying & Filtering](./querying-and-filtering)**: Learn advanced query syntax
 - **[PostgreSQL](./postgresql)**: Connect PostgreSQL databases
 - **[SQLite](./sqlite)**: Connect local SQLite databases
 - **[SQL Server](./sql-server)**: Connect Microsoft SQL Server
 - **[AlloyDB](./alloydb)**: Connect Google AlloyDB
+- **[BigQuery](./bigquery)**: Connect Google BigQuery datasets
 
 For database-specific questions, consult the individual database guides or contact DreamFactory support.

--- a/docs/api-generation-and-connections/schema-contracts.md
+++ b/docs/api-generation-and-connections/schema-contracts.md
@@ -1,0 +1,142 @@
+---
+sidebar_position: 9
+title: Schema Contracts
+id: schema-contracts
+description: "Lock the public shape of a SQL-backed API, detect drift against the live database, and optionally enforce the contract at runtime"
+keywords: [schema contract, drift detection, breaking change, API contract, schema lock, runtime enforcement, OpenAPI]
+difficulty: "advanced"
+---
+
+# Schema Contracts
+
+A generated API follows your database. That is the point — and also the risk: someone drops a column, renames a field, or widens a type, and every consumer of the API discovers it at runtime.
+
+**Schema Contracts** let you lock the shape a SQL service exposes, then tell you when the live database drifts away from it. You can stop there and treat drift as information, or turn on runtime enforcement and have DreamFactory hold the API to the locked shape until you deliberately promote a new one.
+
+Contracts are managed under `/api/v2/system/schema_contract/...` and in the admin UI under **Schema Contracts**.
+
+---
+
+## The workflow
+
+1. **Lock** a table — DreamFactory captures a snapshot of its current shape as the active contract.
+2. **Diff** — drift is computed against the live database whenever you look, so it is always current rather than a cached verdict.
+3. **Promote** — when the drift is intended, promote to make the current shape the new contract.
+
+---
+
+## Locking a table
+
+```bash
+curl -X POST \
+  "https://{instance}/api/v2/system/schema_contract/{service}/tables/{table}/lock" \
+  -H "X-DreamFactory-API-Key: {api_key}"
+```
+
+Each lock stores a versioned snapshot. Previous versions are retained as archives — see [Retention](#retention) below.
+
+---
+
+## Reading contracts and drift
+
+| Endpoint | Returns |
+| --- | --- |
+| `GET /system/schema_contract/{service}` | Service-level contract status |
+| `GET /system/schema_contract/{service}/tables` | Every table and its contract status |
+| `GET /system/schema_contract/{service}/tables/{table}/snapshot` | The active locked contract |
+| `GET /system/schema_contract/{service}/tables/{table}/snapshots` | Snapshot history (append `/{version}` for one) |
+| `GET /system/schema_contract/{service}/tables/{table}/diff` | Drift for one table |
+| `GET /system/schema_contract/{service}/diff` | Drift across the whole service |
+| `GET /system/schema_contract/{service}/tables/{table}/openapi` | OpenAPI schema generated from the contract |
+| `GET /system/schema_contract/{service}/openapi` | OpenAPI for the whole service |
+
+### Drift severity
+
+Every difference is classified, which is what makes drift actionable rather than just a list of changes:
+
+| Severity | Meaning |
+| --- | --- |
+| `breaking` | Consumers will break — a column the contract promised is gone or incompatible |
+| `potentially_breaking` | May break consumers depending on how they use the field |
+| `additive` | New surface; existing consumers are unaffected |
+| `cosmetic` | No consumer-visible effect |
+
+---
+
+## Testing and promoting
+
+Validate a table against its contract without changing anything:
+
+```bash
+curl -X POST \
+  "https://{instance}/api/v2/system/schema_contract/{service}/tables/{table}/test" \
+  -H "X-DreamFactory-API-Key: {api_key}"
+```
+
+Accept the current shape for the whole service:
+
+```bash
+curl -X POST \
+  "https://{instance}/api/v2/system/schema_contract/{service}/promote" \
+  -H "X-DreamFactory-API-Key: {api_key}"
+```
+
+:::note[Promotion requires a mode]
+A service whose `mode` is `none` cannot be promoted — the call fails with a message telling you to set `mode` to `auto` or `strict` first, via `PATCH /system/schema_contract/{service}`.
+:::
+
+Remove a contract with `DELETE .../tables/{table}` for one table, or `DELETE .../{service}` for the whole service.
+
+---
+
+## Service settings
+
+`PATCH /api/v2/system/schema_contract/{service}` configures how a service treats its contracts:
+
+| Setting | Values | Meaning |
+| --- | --- | --- |
+| `mode` | `none`, `auto`, `strict` | Whether contracts apply to this service at all, and how snapshots are managed. `none` also blocks promotion. |
+| `runtime_enforcement` | `off`, `shape_response`, `strict` | Whether the contract is enforced on live traffic. See below. |
+| `archive_retention_count` | integer | How many archived snapshots to keep per table. |
+| `enabled` | boolean | Master switch for the service's contracts. |
+
+---
+
+## Runtime enforcement
+
+By default (`off`) a contract is documentation and a drift signal — it never touches live traffic. The other two modes change that:
+
+**`shape_response`** — on the way out, response fields that are not in the table's active locked contract are stripped. This applies to *every* verb's response body, including the rows returned by `POST`, `PUT`, `PATCH` and `DELETE` acknowledgements via `?fields=`, so a column added to the database stays invisible to consumers until you re-lock or promote.
+
+**`strict`** — everything `shape_response` does, plus writes are rejected before they run when the payload references fields outside the contract, or writes to fields the contract marks read-only. Payloads are inspected in any of the shapes DreamFactory accepts: wrapped in `resource`, a bare list, or a bare record.
+
+:::warning[shape_response hides new columns from consumers]
+This is the intended behaviour — a locked contract means the API's shape does not change under consumers' feet — but it does mean that adding a column to the database and expecting it in API responses will appear to do nothing until the contract is promoted. If a new field is "missing" from responses on a service with enforcement on, check the contract before checking the database.
+:::
+
+---
+
+## Command line
+
+```bash
+# Emit the canonical JSON schema for a service (or one table)
+php artisan schema-contracts:describe {service} [--table=orders] [--pretty]
+
+# Delete surplus archived snapshots per each service's archive_retention_count
+php artisan schema-contracts:prune [--service=name] [--dry-run]
+```
+
+`--dry-run` reports what would be deleted without applying it.
+
+---
+
+## Retention {#retention}
+
+Every lock and promotion archives the previous snapshot. `archive_retention_count` caps how many are kept per table, and `schema-contracts:prune` applies that policy — run it on a schedule if you lock frequently.
+
+---
+
+## Next steps
+
+- **[Generating a Database-Backed API](./api-types/database/generating-a-database-backed-api)**: Create the service a contract locks
+- **[Role-Based Access Control](/Security/role-based-access)**: Restrict who may lock or promote

--- a/docs/api-generation-and-connections/services-list.md
+++ b/docs/api-generation-and-connections/services-list.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 10
+title: The Services List
+id: services-list
+description: "Read the Services list in the DreamFactory admin console, including the Health column that scores role access and probes each service's live connection"
+keywords: [services list, API health, service health, connection check, RBAC, admin console]
+difficulty: "beginner"
+---
+
+# The Services List
+
+Every generated API appears in the Services list, grouped by type under **API Generation & Connections** — Database, Scripting, Network, File, Utility, and the read-only **DreamFactory Platform APIs**.
+
+Alongside each service's name, label, description and type, the list carries a **Health** column.
+
+---
+
+## The Health column
+
+Health answers a narrow, practical question: *would a call to this service work right now?* It combines two independent signals.
+
+**Governance** — does any active role grant a key access to this service? A service no role can reach is unreachable by any API key, however well configured it otherwise is.
+
+**Connection** — can the service actually answer? DreamFactory probes it live: `/_schema` for database services, `/` for file storage. Service types with no defined probe are not guessed at.
+
+| Chip | Meaning |
+| --- | --- |
+| **Healthy** | A role grants access *and* the connection answered |
+| **Action required** | Something is wrong — open the service to see what |
+| **Not checked** | Governance passed, but this API type has no automatic connection check |
+| **Checking…** | The probe is in flight |
+
+:::note[Healthy means verified, not assumed]
+"Not checked" is deliberately distinct from "Healthy". A scripting, remote or authentication service has no connection DreamFactory knows how to test, so it reports that it was not checked rather than claiming health it cannot prove. Only a service whose connection actually answered reports Healthy.
+:::
+
+Selecting a flagged chip lists the failing checks, each linking to the configuration that clears it.
+
+### What it costs
+
+The connection probe runs for the services **on the current page** of the list, not the whole catalog — cost tracks your page size, not how many services you have. Verdicts are cached per service, so paging back and forth does not reopen connections.
+
+The **DreamFactory Platform APIs** list has no Health column: those services are reached with an admin session rather than a role grant, and have no connection to probe, so neither signal would say anything meaningful.
+
+---
+
+## Health on a service's own page
+
+Opening a service shows the same verdict expanded: one row per failing check, each with a link to the configuration that fixes it, and — for a failed connection — the error from the driver, with the status, request and raw response behind a **Details** expander.
+
+A service with nothing to act on collapses to a single line, so the panel stays out of the way of the configuration form.
+
+---
+
+## Next steps
+
+- **[Role-Based Access Control](/Security/role-based-access)**: Grant a role access to a service
+- **[API Keys](./api-keys)**: Bind a key to a role

--- a/docs/getting-started/installing-dreamfactory/docker-installation.md
+++ b/docs/getting-started/installing-dreamfactory/docker-installation.md
@@ -9,7 +9,7 @@ difficulty: beginner
 
 # Docker installation
 
-Our Docker container includes everything you need to run DreamFactory, including Ubuntu 22.04, PHP 8.1, and the NGINX web server. It also includes all required PHP extensions and a sample Postgres Database. With these tools you can begin experimenting with the latest DreamFactory version as quickly as you can spin up the container!
+Our Docker container includes everything you need to run DreamFactory, including Ubuntu, PHP 8.3+, and the NGINX web server. It also includes all required PHP extensions and a sample Postgres Database. With these tools you can begin experimenting with the latest DreamFactory version as quickly as you can spin up the container!
 
 ## Prerequisites
 

--- a/docs/getting-started/installing-dreamfactory/linux-installation.md
+++ b/docs/getting-started/installing-dreamfactory/linux-installation.md
@@ -63,7 +63,7 @@ You can now access the DreamFactory UI from a web browser by pointing to the ser
 
 ## Installing DreamFactory on Ubuntu 22.04/24.04
 
-Ubuntu is the most commonly used Linux distribution for DreamFactory deployments. The automated installer handles all dependency installation (PHP 8.1+, NGINX, MariaDB) automatically on Ubuntu 22.04 LTS and Ubuntu 24.04 LTS.
+Ubuntu is the most commonly used Linux distribution for DreamFactory deployments. The automated installer handles all dependency installation (PHP 8.3+, NGINX, MariaDB) automatically on Ubuntu 22.04 LTS and Ubuntu 24.04 LTS.
 
 ```bash
 # Download the installer
@@ -114,7 +114,7 @@ chmod +x dfsetup.run
 sudo ./dfsetup.run
 ```
 
-Debian 10/11 uses `apt` as its package manager. The installer automatically detects the Debian variant and selects the correct package repositories for PHP 8.1+ and NGINX.
+Debian 10/11 uses `apt` as its package manager. The installer automatically detects the Debian variant and selects the correct package repositories for PHP 8.3+ and NGINX.
 
 ## Installing DreamFactory on Fedora
 

--- a/docs/getting-started/installing-dreamfactory/windows-installation.md
+++ b/docs/getting-started/installing-dreamfactory/windows-installation.md
@@ -20,7 +20,7 @@ Before starting the installation, confirm all of the following are in place:
   ```powershell
   Enable-WindowsOptionalFeature -Online -FeatureName IIS-CGI
   ```
-- [ ] **PHP 8.1 or 8.3** — use the **Non-Thread-Safe (NTS)** build for IIS/FastCGI deployments. Download from [windows.php.net](https://windows.php.net/download/).
+- [ ] **PHP 8.3 or later** — use the **Non-Thread-Safe (NTS)** build for IIS/FastCGI deployments. Download from [windows.php.net](https://windows.php.net/download/).
 - [ ] **Composer** — PHP dependency manager. Download the installer from [getcomposer.org](https://getcomposer.org/Composer-Setup.exe).
 - [ ] **Git for Windows** — required to clone the DreamFactory repository. Download from [git-scm.com](https://git-scm.com/download/win).
 - [ ] **Visual C++ 2015–2019 Redistributable** — required by PHP and its extensions on Windows. Download from [Microsoft](https://aka.ms/vs/16/release/VC_redist.x64.exe).

--- a/docs/system-settings/config/cors-ssl.md
+++ b/docs/system-settings/config/cors-ssl.md
@@ -16,6 +16,12 @@ This chapter covers two critical security aspects of your DreamFactory environme
 
 CORS (Cross-Origin Resource Sharing) is a mechanism that allows a client to interact with an API endpoint which hails from a different domain, subdomain, port, or protocol. DreamFactory is configured by default to disallow all outside requests, so before you can integrate a third-party client such as a web or mobile application, you'll need to enable CORS.
 
+:::note[With no CORS entry, no CORS headers are sent]
+"Disallow all outside requests" is literal: until you create an entry, DreamFactory returns no `Access-Control-*` headers at all and rejects preflight (`OPTIONS`) requests. A browser client will report a CORS failure rather than a permission error from the API.
+
+If cross-origin calls that used to work start failing after an upgrade, check that an entry exists for the path in question — earlier versions could emit a permissive `Access-Control-Allow-Origin: *` from framework defaults even with no entry configured.
+:::
+
 ### Configuring CORS in DreamFactory
 
 To modify your CORS settings, log in to your DreamFactory instance using an administrator account and select the System Settings tab. Next navigate to `Config > CORS`, and then click the purple plus button to establish a new connection:

--- a/docs/upgrades-and-migrations/upgrading-migrating-dreamfactory.md
+++ b/docs/upgrades-and-migrations/upgrading-migrating-dreamfactory.md
@@ -30,7 +30,7 @@ Use the table below to identify the appropriate upgrade method based on your cur
 |---|---|---|---|
 | 4.x | 5.x | In-place (`git pull`) | PHP 7.4+ required; run `php artisan migrate --seed` |
 | 5.x | 6.x | In-place (`git pull`) | Review `.env` for new required variables; check deprecated connectors |
-| 6.x | 7.x | In-place or fresh migration | PHP 8.1+ required; significant dependency updates — test in staging first |
+| 6.x | 7.x | In-place or fresh migration | PHP 8.3+ required; significant dependency updates — test in staging first |
 | Any | Cross-server | Full migration (see below) | Use the Major Version Migration process to copy `.env` and system database |
 
 **Breaking changes to watch for:**
@@ -413,7 +413,7 @@ scp <user>@<remote-server>:/opt/dreamfactory/dump.sql .
 If upgrading MySQL versions (e.g., 5.6 to 5.7+), you may need to disable strict mode by opening `config/database.php` and adding `'strict' => false` under the MySQL configuration section.
 
 #### General Configuration
-Ensure all system dependencies are up to date. DreamFactory supports PHP 8.1 or later.
+Ensure all system dependencies are up to date. DreamFactory 7.x requires PHP 8.3 or later.
 
 ### Step 5: Import the System Database
 
@@ -479,6 +479,23 @@ php artisan cache:clear
 ```bash
 php artisan config:clear
 ```
+
+## Configuration Notes for Laravel 13-Based Releases
+
+:::warning[`config/cache.php` must allow class unserialization]
+Laravel 13 added a `serializable_classes` key to `config/cache.php` and ships it as `false`, which prevents *any* PHP class from being restored from the cache. That default is unsafe for DreamFactory, which caches objects — database schema and event scripts among them.
+
+Under `false`, cached objects come back as `__PHP_Incomplete_Class` and fail at the first property access. The symptom is distinctive: an endpoint answers **200 on the first request after a cache clear, then 500 on every request after it**, because the first request populates the cache and the second reads it back.
+
+```php
+// config/cache.php
+'serializable_classes' => true,
+```
+
+This affects the `redis`, `file`, `database`, `array`, `dynamodb` and `storage` cache stores — all the ones that serialize through PHP. Switching stores is not a workaround.
+
+Installations that upgrade in place usually keep their existing `config/cache.php`, which has no such key and is therefore unaffected. The problem appears on **fresh installs**, and on any instance that adopts the new skeleton's configuration file.
+:::
 
 ## Migration Verification
 


### PR DESCRIPTION
Four features ship in the current composers with no documentation at all, and the platform baseline had drifted. Written against the packages themselves rather than release notes, so the behaviours documented are the ones the code actually implements.

New pages:

- BigQuery connector. The connector existed undocumented and has since gained writes, so this covers config, reads, and the full write path - including the rule a user hits first: BigQuery enforces no primary keys, so id-addressed calls need an explicit id_field and may match zero or many rows.
- Agents. The service, its three resources, and POST /agents/route - documenting the scoring (skills weigh 3, name/description 1, ties by lowest id) because it is deterministic, so callers can predict and tune routing. Notes that the router returns a decision and never a credential.
- Schema Contracts. Lock/diff/promote, the four drift severities, and runtime enforcement - with the consequence spelled out: under shape_response a newly added column stays invisible to consumers until the contract is promoted, which otherwise reads as a bug.
- The Services list, as the home for the Health column: its four states and why "Not checked" is deliberately not "Healthy".

Edits:

- AI usage: the task cost estimator, and why it reports a range (the tool loop fans one task into 3-6 provider calls).
- AI chat: suggested follow-up chips from a trailing suggestions fence.
- CORS: with no entry configured, no Access-Control-* headers are sent at all. Earlier versions could emit a permissive wildcard from framework defaults, so cross-origin calls that used to work may stop after an upgrade.
- Upgrades: Laravel 13 ships cache.serializable_classes as false, which DreamFactory cannot run under - cached objects return as __PHP_Incomplete_Class, so an endpoint answers 200 once and 500 after. Scoped to Laravel 13-based releases rather than stated as current.
- PHP baseline 8.1 -> 8.3 across the install and upgrade guides, matching the composer constraint. Laravel 13 and PHP 8.5 are deliberately not claimed anywhere: the shipping release is laravel ^11.15.
- database-overview: BigQuery added, plus two pre-existing broken links fixed (both pages set a custom id, so the file-name paths never resolved).